### PR TITLE
2주차 커밋: 뉴스 클러스터링, N개의 최소공배수

### DIFF
--- a/bmo/week2/N개의 최소공배수.py
+++ b/bmo/week2/N개의 최소공배수.py
@@ -1,0 +1,25 @@
+def getDivisor(number):
+    divisor = dict()
+    while number != 1:
+        for i in range(2, number+1):
+            if number % i == 0:
+                divisor[i] = divisor.get(i, 0) + 1
+                break
+        number = number // i
+    return divisor
+
+def solution(arr):
+    answer = 1
+    divisor_union = dict()
+
+    for divisors in [getDivisor(num) for num in arr]:
+        for key, value in divisors.items():
+            divisor_union[key] = max(divisor_union.get(key, 0), value)
+    
+    for key, value in divisor_union.items():
+        answer *= key ** value
+
+    return answer
+
+if __name__ == '__main__':
+    print(solution([2,6,8,14]))

--- a/bmo/week2/뉴스 클러스터링.py
+++ b/bmo/week2/뉴스 클러스터링.py
@@ -1,0 +1,21 @@
+def getGroup(arr):
+    group = dict()
+    for letter in zip(arr, arr[1:]):
+        c = ''.join(letter).upper()
+        if c.isalpha():
+            group[c] = group.get(c, 0) + 1
+    return group
+
+def solution(str1, str2):
+    group1 = getGroup(str1)
+    group2 = getGroup(str2)
+    intersection = 0
+    union = 0
+
+    for c in (set(group1.keys()) & set(group2.keys())):
+        intersection += min(group1.get(c, 0), group2.get(c, 0))
+
+    for c in (set(group1.keys()) | set(group2.keys())):
+        union += max(group1.get(c, 0), group2.get(c, 0))
+    
+    return int((intersection / union) * 65536) if union != 0 else 65536

--- a/bmo/week2/땅따먹기.py
+++ b/bmo/week2/땅따먹기.py
@@ -1,0 +1,6 @@
+def solution(land):
+    for row in range(1, len(land)):
+        for col, score in enumerate(land[row]):
+            land[row][col] += max(land[row-1][:col] + land[row-1][col+1:])
+
+    return max(land[-1])

--- a/bmo/week2/자물쇠와 열쇠.py
+++ b/bmo/week2/자물쇠와 열쇠.py
@@ -1,0 +1,41 @@
+def rotation(key):
+    m = len(key)
+    rotate_key = [[0] * len(key[0]) for _ in range(len(key))]
+    for row in range(m):
+        for i in range(m):
+            rotate_key[i][m-1 - row] = key[row][i]
+    return rotate_key
+
+def check(bigLock):
+    n = len(bigLock) // 3
+    for i in range(n, n * 2):
+        for j in range(n, n * 2):
+            if bigLock[i][j] != 1:
+                return False
+    return True
+    
+def solution(key, lock):
+    n = len(lock)
+    m = len(key)
+    #자물쇠를 가운데 배치
+    bigLock = [[0] * 3 * n for _ in range(3 * n)]
+    for i in range(n):
+        bigLock[n + i][n : 2 * n] = lock[i]
+    
+    for angle in range(4):
+        key = rotation(key)
+        for row in range(n * 2):
+            for col in range(n * 2):
+
+                for i in range(m):
+                    for j in range(m):
+                        bigLock[row+i][col+j] += key[i][j]
+
+                if check(bigLock):
+                    return True
+                
+                for i in range(m):
+                    for j in range(m):
+                        bigLock[row+i][col+j] -= key[i][j]
+    
+    return False

--- a/bmo/week2/최고의 집합.py
+++ b/bmo/week2/최고의 집합.py
@@ -1,21 +1,9 @@
-import itertools
-
 def solution(n, s):
-    answer = []
-    numbers = [_ for _ in range(1, s)]
-    combis = set()
+    if n > s: return [-1]
 
-    for combi in itertools.combinations(numbers, n):
-        if sum(combi) == s:
-            combis.add((combi[0] * combi[1], combi))
-    if s % 2 == 0: combis.add(((s//2)**2, (s//2, s//2)))
-    
-    if not combis: return [-1]
-    for number in sorted(list(combis), reverse= True)[0][1]:
-        answer.append(number)
-    
-    return answer
+    answer = [s//n for _ in range(n)]
 
-if __name__ == '__main__':
-    result = solution(2, 8)
-    print(result)
+    for idx in range(s % n):
+        answer[idx] += 1
+
+    return sorted(answer)

--- a/bmo/week2/최고의 집합.py
+++ b/bmo/week2/최고의 집합.py
@@ -4,6 +4,6 @@ def solution(n, s):
     answer = [s//n for _ in range(n)]
 
     for idx in range(s % n):
-        answer[idx] += 1
+        answer[-1 - idx] += 1
 
-    return sorted(answer)
+    return answer

--- a/bmo/week2/최고의 집합.py
+++ b/bmo/week2/최고의 집합.py
@@ -1,0 +1,21 @@
+import itertools
+
+def solution(n, s):
+    answer = []
+    numbers = [_ for _ in range(1, s)]
+    combis = set()
+
+    for combi in itertools.combinations(numbers, n):
+        if sum(combi) == s:
+            combis.add((combi[0] * combi[1], combi))
+    if s % 2 == 0: combis.add(((s//2)**2, (s//2, s//2)))
+    
+    if not combis: return [-1]
+    for number in sorted(list(combis), reverse= True)[0][1]:
+        answer.append(number)
+    
+    return answer
+
+if __name__ == '__main__':
+    result = solution(2, 8)
+    print(result)


### PR DESCRIPTION
# 문제 1 뉴스 클러스터링
셋과 딕셔너리를 사용하여 풀었습니다. 셋은 중복을 제거하기 때문에 셋만 사용해서는 자카드 지수를 구할 수 없었습니다. 
1. getGroup함수에서 `두글자씩 만든 문자열`-`출현 빈도` 쌍을 반환합니다
2. 교집합 원소의 갯수는 해당 문자열이 더 적게 나타난 값을 더해가면서 구할 수 있습니다. 
3. 합집합 원소 갯수는 반대로 더 많은 value값을 갖는 쪽을 더해가는 식으로 구합니다. 

예: {'AA', 'AA'}, {'AA', 'AA', 'AA'} -> {'AA':2}, {'AA': 3} ->  교집합: 2 합집합: 3
- 시간복잡도: O(N)
# 문제 3 N개의 최소 공배수
뉴스 클러스터링 문제와 비슷하게 푼거 같습니다. 
각 숫자들을 인수분해해 그 합집합 원소들을 모두 곱한다면 모든 수의 최소 공배수를 구할 수있습니다. 
1. getDivisor함수를 통해 해당 숫자를 인수분해하고 딕셔너리로 인수분해 결과를 반환합니다. 
예: 8 = 2*2*2 => {2:3}
2. `divisor_union`딕셔너리에 약수: 약수의 최대 출현빈도를 갱신하는 식으로 합집합을 나타냅니다
예: 2, 8 -> 2, 2x2x2 -> {2}, {2, 2, 2} -> 합집합={2, 2, 2}
딕셔너리로 표현하면 👉    {2:1}, {2:3}    -> 합집합={2:3} 
- 시간 복잡도: O(N^2)