### PR TITLE
4주차 커밋: 괄호 회전하기, 더 맵게, 영어 끝말잇기, 베스트앨범, 여행경로

### DIFF
--- a/bmo/week4/괄호 회전하기.py
+++ b/bmo/week4/괄호 회전하기.py
@@ -1,0 +1,27 @@
+def valid(s):
+    stack = []
+    bracket = {
+        ']' : '[',
+        '}' : '{',
+        ')' : '('
+    }
+    
+    for c in s:
+        if c in bracket.values():
+            stack.append(c)
+        else:
+            if stack and stack[-1] == bracket[c]:
+                stack.pop()
+            else:
+                return False
+    return True if not stack else False
+
+def solution(s):
+    answer = 0
+
+    for x in range(len(s)):
+        brackets = s[x:] + s[:x]
+        if valid(brackets):
+            answer += 1
+
+    return answer

--- a/bmo/week4/더 맵게.py
+++ b/bmo/week4/더 맵게.py
@@ -1,0 +1,18 @@
+import heapq
+
+def solution(scoville, K):
+    answer = 0
+    heapq.heapify(scoville)
+
+    while scoville:
+        min1 = heapq.heappop(scoville)
+        if min1 >= K:
+            return answer
+
+        if not scoville:
+            return -1
+        
+        min2 = heapq.heappop(scoville)
+
+        heapq.heappush(scoville, min1 + min2 * 2)
+        answer += 1 

--- a/bmo/week4/베스트앨범.py
+++ b/bmo/week4/베스트앨범.py
@@ -6,9 +6,7 @@ def solution(genres, plays):
         genreRank[genre] = genreRank.get(genre, 0) + play
     songs.sort(reverse=True, key=lambda x: (x[2], -x[0]))
     
-    genreRank = sorted(genreRank.items(), reverse=True, key=lambda x: x[1])
-    if len(genreRank) > 2:
-        genreRank = genreRank[:2] 
+    genreRank = sorted(genreRank.items(), reverse=True, key=lambda x: x[1]) 
 
     for best, play in genreRank:
         count = 0
@@ -17,6 +15,3 @@ def solution(genres, plays):
                 answer.append(song[0])
                 count += 1
     return answer
-
-if __name__ == '__main__':
-    print(solution(["classic", "pop", "pop"], [500, 1000, 200]))

--- a/bmo/week4/베스트앨범.py
+++ b/bmo/week4/베스트앨범.py
@@ -1,0 +1,22 @@
+def solution(genres, plays):
+    answer = []
+    genreRank = dict()
+    songs = [(idx, genre, play) for idx, (genre, play) in enumerate(zip(genres, plays))]
+    for idx, genre, play in songs:
+        genreRank[genre] = genreRank.get(genre, 0) + play
+    songs.sort(reverse=True, key=lambda x: (x[2], -x[0]))
+    
+    genreRank = sorted(genreRank.items(), reverse=True, key=lambda x: x[1])
+    if len(genreRank) > 2:
+        genreRank = genreRank[:2] 
+
+    for best, play in genreRank:
+        count = 0
+        for song in songs:
+            if song[1] == best and count < 2:
+                answer.append(song[0])
+                count += 1
+    return answer
+
+if __name__ == '__main__':
+    print(solution(["classic", "pop", "pop"], [500, 1000, 200]))

--- a/bmo/week4/여행경로.py
+++ b/bmo/week4/여행경로.py
@@ -1,0 +1,21 @@
+def solution(tickets):
+    answer = []
+    flight = dict()
+
+    for source, destination in tickets:
+        flight[source] = flight.get(source, []) + [destination]
+    for source in flight:
+        flight[source].sort(reverse=True)
+    
+    stack = ["ICN"]
+
+    while stack:
+        if stack[-1] not in flight.keys() or not flight[stack[-1]]:
+            answer.append(stack.pop())
+        else:
+            stack.append(flight[stack[-1]].pop())
+    
+    return answer[::-1]
+
+if __name__ == '__main__':
+    print(solution([["ICN", "SFO"], ["ICN", "ATL"], ["SFO", "ATL"], ["ATL", "ICN"], ["ATL","SFO"]]		))

--- a/bmo/week4/여행경로.py
+++ b/bmo/week4/여행경로.py
@@ -16,6 +16,3 @@ def solution(tickets):
             stack.append(flight[stack[-1]].pop())
     
     return answer[::-1]
-
-if __name__ == '__main__':
-    print(solution([["ICN", "SFO"], ["ICN", "ATL"], ["SFO", "ATL"], ["ATL", "ICN"], ["ATL","SFO"]]		))

--- a/bmo/week4/영어 끝말잇기.py
+++ b/bmo/week4/영어 끝말잇기.py
@@ -1,0 +1,11 @@
+def solution(n, words):
+    answer = [0, 0]
+    history = set([words[0]])
+
+    for idx in range(1, len(words)):
+        if words[idx - 1][-1] == words[idx][0] and len(words[idx]) > 1 and words[idx] not in history:
+            history.add(words[idx])
+        else:
+            answer = [idx % n + 1, idx // n + 1]
+            break
+    return answer


### PR DESCRIPTION
# 문제1 더 맵게
1. `힙`을 사용하여 가장 낮은 스코빌 원소가 K보다 크면 그때까지의 수행 횟수를 반환합니다
2. 더 이상 조합하지 못하면 (min1을 꺼낸 후 더 꺼낼 원소가 없을 떄) -1을 반환합니다
3. 새 스코빌 지수를 만들어 힙에 넣고 수행 횟수를 올립니다
- 시간 복집도: O(n)
# 문제2 괄호 회전하기
1. `valid`함수에서 알맞은 괄호 모양인지 판단합니다
  닫는 괄호를 키로 하는 괄호 쌍을 딕셔너리에 저장하고 문자열에서 닫는 괄호가 나오면 직전의 문자와 쌍이 맞는지 확인합니다.
2. 괄호 회전은 x칸 만큼 자르고 자른 부분을 끝에 붙이는 식으로 x칸 회전을 구현했습니다
- 시간 복잡도: O(n)
# 문제3 영어 끝말잇기
1. 앞단어의 끝 문자 == 지금 단어의 앞글자 `words[idx - 1][-1] == words[idx][0]`
2. 한 글자 이상인지 `len(words[idx]) > 1`
3. 이전에 말한 단어인지 `words[idx] not in history`

탈락한 인덱스에서 인원수를 이용하여 [사람번호, 몇번째 반복]를 반환합니다
- 시간 복잡도: O(n)
- 3번 조건 효율성을 위해 set을 사용하였지만 시간 차이가 별로 나지 않아서 그냥 리스트 사용해도 괜찮을 거 같다는 생각이 듭니다...🤓

# 문제4 베스트앨범
1. genreRanck { 장르: 플레이 누적} 딕셔너리로 정렬을 통해 상위 2개 장르를 알아냅니다
2. songs (번호, 장르, 플레이수)를 저장하는 리스트입니다. 플레이 내림차순, 번호 오름차순으로 정렬됩니다.
3. 상위 2개 장르의 음악을 answer리스트에 2개씩 담습니다. 장르 음악이 1개이면 1개만 들어갑니다. 
- 아직 테스트케이스 절반은 통과하지 못해서 어떤 반례가 있는지 생각중입니다😅 
# 문제5 여행경로
1. 출발 공항에서 가능한 항공편들을 `flight`딕셔너리 key(출발지) - value(도착지 리스트)로 저장합니다
  다수의 도착지가 있는 경우 알파벳이 앞서는 공항부터 가기 때문에 이부분을 위해 value 도착지 리스트를 알파벳 역순으로 정렬하여 알파벳 순으로 **pop**할 수 있도록 합니다. 
2. 경로는 역순으로 출력됩니다. stack 마지막 원소는 현재 공항이라고 생각합니다. 
3. 현재 공항에서 갈 수 있는 다른 공항이 있다면 그 공항을 stack에 추가합니다. 
4. 현재 공항에서 갈 수 있는 공항이 없다면 경로에 추가합니다
- 시간 복잡도: O(n)