### PR TITLE
[비모] 5주차 메뉴리뉴얼, 등굣길, n퀸

### DIFF
--- a/bmo/week5/N-Queen.py
+++ b/bmo/week5/N-Queen.py
@@ -1,0 +1,21 @@
+def dfs(board, row, n):
+    count = 0
+
+    if row == n:
+        return 1
+    
+    for col in range(n):
+
+        for i in range(row):
+            if board[i] == col: 
+                break
+            if board[i] + i == row + col or board[i] - i == col - row:
+                break
+        else:
+            board[row] = col
+            count += dfs(board, row+1, n)
+            
+    return count
+
+def solution(n):
+    return dfs([-1]*n, 0, n)

--- a/bmo/week5/등굣길.py
+++ b/bmo/week5/등굣길.py
@@ -1,0 +1,12 @@
+def solution(m, n, puddles):
+    puddles = set((y, x) for x, y in puddles)
+    dp = [[0] * (m+1) for _ in range(n+1)]
+    dp[1][1] = 1
+    
+    for i in range(1, n+1):
+        for j in range(1, m+1):
+            if (i, j) in puddles or (i, j) == (1, 1):
+                continue
+            dp[i][j] = (dp[i-1][j] + dp[i][j-1]) % 1_000_000_007
+
+    return dp[-1][-1]

--- a/bmo/week5/메뉴 리뉴얼.py
+++ b/bmo/week5/메뉴 리뉴얼.py
@@ -1,0 +1,24 @@
+import itertools
+
+def solution(orders, course):
+    answer = []
+    courses = [dict() for _ in range(len(course))]
+    
+    for order in orders:
+        for i in range(len(course)):
+            if course[i] <= len(order):
+                for combi in itertools.combinations(order, course[i]):
+                    menu = ''.join(sorted(combi))
+                    courses[i][menu] = courses[i].get(menu, 0) + 1
+    
+    for newMenu in courses:
+        if not newMenu:
+            continue
+        max_count = max(newMenu.values())
+        if max_count < 2:
+            continue
+        for key, value in newMenu.items():
+            if value == max_count:
+                answer.append(key)
+    
+    return sorted(answer)

--- a/bmo/week5/타겟 넘버.py
+++ b/bmo/week5/타겟 넘버.py
@@ -1,0 +1,11 @@
+import itertools
+
+def solution(numbers, target):
+    answer = 0
+    number = [(num, -num) for num in numbers]
+
+    for combi in itertools.product(*number):
+        if sum(combi) == target:
+            answer += 1
+
+    return answer


### PR DESCRIPTION
# 메뉴 리뉴얼
조합이 나오면 저는 항상 `itertools`모듈을 찾게 되는거 같네요😅 
1. 각 주문들을 돌면서 만들 수 있는 메뉴 조합의 호출 횟수를 딕셔너리 value로 누적해 나갑니다
2. 조합수 별로 가장 많이 주문된 메뉴를 찾을 수 있습니다
- 시간 복잡도: O(NM)

# N-Queen
 풀어도 또 풀어도 까먹는 백트랙킹...
- `board`는 n크기의 체스판에 row의 윗줄까지 퀸들이 위치한 col값을 저장한 1차원 리스트입니다
- 현재 줄의 col에 새로운 퀸이 놓일 수 있는지 열, 대각선을 확인합니다
- 윗 열 또는 대각선에 퀸이 있다면 현재 col에 놓일 수 없으므로 다음 열로 이동합니다
- 해당 col에 놓일 수 있다면 row+1로 다음 행에서 퀸이 놓일 곳을 찾습니다  
- 시간 복집도: O(n^2)?

# 등굣길
DP를 이용하였습니다
1. [i][j] 칸으로 가는 경우의 수는 바로 위 영역`[i-1][j]`과 전 영역`[i][j-1]`의 경우의 수가 더해진 값입니다
- 시간 복잡도: O(NM)