### PR TITLE
[비모] 완주하지 못한 선수, 인형뽑기, 예상 대진표

### DIFF
--- a/bmo/week6/예상대진표.py
+++ b/bmo/week6/예상대진표.py
@@ -1,0 +1,10 @@
+def solution(n, a, b):
+    answer = 1
+    while True:
+        if abs(a - b) == 1 and max(a, b) % 2 == 0:
+            break
+        a = a // 2 if a % 2 == 0 else (a // 2) + 1
+        b = b // 2 if b % 2 == 0 else (b // 2) + 1
+        answer += 1
+
+    return answer

--- a/bmo/week6/예상대진표.py
+++ b/bmo/week6/예상대진표.py
@@ -1,10 +1,13 @@
+def next_stage(num):
+    return num //2 if num % 2 == 0 else (num // 2) + 1
+
 def solution(n, a, b):
     answer = 1
     while True:
         if abs(a - b) == 1 and max(a, b) % 2 == 0:
             break
-        a = a // 2 if a % 2 == 0 else (a // 2) + 1
-        b = b // 2 if b % 2 == 0 else (b // 2) + 1
+        a = next_stage(a)
+        b = next_stage(b)
         answer += 1
 
     return answer

--- a/bmo/week6/완주하지못한선수.py
+++ b/bmo/week6/완주하지못한선수.py
@@ -1,0 +1,14 @@
+from collections import defaultdict
+
+def solution(participant, completion):
+    participants = defaultdict(int)
+    
+    for name in participant:
+        participants[name] += 1
+    
+    for name in completion:
+        participants[name] -= 1
+    
+    for key, value in participants.items():
+        if value == 1:
+            return key

--- a/bmo/week6/이중우선순위큐.py
+++ b/bmo/week6/이중우선순위큐.py
@@ -1,0 +1,20 @@
+from collections import deque
+
+def solution(operations):
+    queue = deque()
+    for operation in operations:
+        op = operation.split()
+
+        if op[0] == 'I':
+            queue.append(int(op[1]))
+        else:
+            if not queue:
+                continue
+
+            queue = deque(sorted(list(queue)))
+            if op[1] == '1':
+                queue.pop()
+            else:
+                queue.popleft()
+
+    return [max(queue), min(queue)] if queue else [0, 0]

--- a/bmo/week6/크레인 인형뽑기 게임.py
+++ b/bmo/week6/크레인 인형뽑기 게임.py
@@ -1,0 +1,29 @@
+def solution(board, moves):
+    answer = 0
+    stack = []
+    n = len(board)
+    lines = [[] for _ in range(n)]
+    
+    # 0을 제외한 원소만 해당 '열' 리스트에 추가
+    for i in range(n-1, -1, -1):
+        for j in range(n):
+            if board[i][j] != 0:
+                lines[j].append(board[i][j])
+    
+    # 플레이
+    for move in moves:
+        if not lines[move-1]:
+            continue
+        curr = lines[move-1].pop()
+
+        if stack and stack[-1] == curr:
+            stack.pop()
+            answer += 2
+        else:
+            stack.append(curr)
+
+    return answer
+
+
+if __name__ == '__main__':
+    print(solution([[0,0,0,0,0],[0,0,1,0,3],[0,2,5,0,1],[4,2,4,4,2],[3,5,1,3,1]], [1,5,3,5,1,2,1,4]))

--- a/bmo/week6/후보키.py
+++ b/bmo/week6/후보키.py
@@ -1,0 +1,24 @@
+import itertools
+
+def solution(relation):
+    n = len(relation[0])
+    keys = set()
+
+    for i in range(1, n+1):
+        for combi in itertools.combinations([i for i in range(n)], i):
+            records = set()
+            for rel in relation:
+                record = ''
+                for col in combi:
+                    record += rel[col]
+                records.add(record)
+
+            # 식별자가 된 경우 후보키 여부 판별
+            if len(records) == len(relation):
+                for key in keys:
+                    if not set(key) - set(combi):
+                        break
+                else:
+                    keys.add(combi)
+                    
+    return len(keys)      


### PR DESCRIPTION
# 1. 완주하지 못한 선수
1. `defaultdict`를 사용하여 참가자 이름과 해당 이름 빈도를 나타내도록 하였습니다
2. participant 원소들을 돌 때 해당 이름의 횟수를 더해나갑니다 (동명이인도 있기 때문)
3. completion 원소들을 돌 때 해당 이름의 횟수를 하나씩 뺍니다.
4. 최종적으로 value가 1 남은 key값이 바로 완주하지 못한 한 명입니다. 
- 시간 복잡도: O(N)
# 2. 크레인 인형뽑기 게임
`스택`을 사용하여 풀었습니다. 
1.  moves는 열만 주어지기 때문에 board 정보를 각각의 열에 대한 리스트로 두고 열은 스택으로 생각하였습니다. 
2. 열에서 pop한 원소를 가지고 바구니에서 가장 위쪽 원소와 비교합니다. (올바른 괄호 문제와 유사)  
3. 짝이 같은 원소들이 만난다면 바구니에서 pop하고 없어진 인형개수를 2개 올립니다
4. 짝이 같지 않다면 바구니에 append합니다
- 시간 복잡도: O(N^2)
# 3. 예상 대진표
1.  해당 라운드에서 만나는 조건은 두 번호의 차이가 1이고 그 중 큰 수가 짝수여야합니다. 
2.  한 라운드가 올라갈때 기존 번호가 짝수라면 `기존번호 // 2` , 홀수라면 `(기존번호 // 2) + 1`로 변합니다.  라운드 수`answer`도 1 올려줍니다
- 시간 복잡도: O(logN)