### PR TITLE
yeoun-week6

### DIFF
--- a/yeoun/week6/예상 대진표.py
+++ b/yeoun/week6/예상 대진표.py
@@ -1,0 +1,35 @@
+# a,b 참가자가 현재 라운드에서 만나면 True, 아니면 False 
+# 둘의 차가 1이고, 큰 값이 짝수여야 만남 
+def check_if_meet(a,b):
+    if a < b:
+        if b-a == 1 and a % 2 == 1 and b % 2 == 0:
+            return True
+
+    else: # a > b
+        if a-b == 1 and a % 2 == 0 and b % 2 == 1:
+            return True
+    
+    return False 
+
+# 다음 라운드에 배정되는 번호를 반환함
+def next_num(player):
+    # 짝수면 현재 번호를 2로 나눈 값
+    if player % 2 == 0:
+        return player // 2 
+    # 홀수면 (현재 번호 + 1)을 2로 나눈 값 
+    else:
+        return (player+1)//2 
+
+def solution(n,a,b):
+    # a,b가 만나는 라운드의 번호 
+    answer = 1
+    
+    # 현재 라운드에서 만나면 while문 탈출 
+    while not check_if_meet(a,b):
+        # 다음 라운드의 번호로 갱신 
+        a = next_num(a)
+        b = next_num(b)
+        # 라운드 번호 +1 
+        answer += 1 
+            
+    return answer 

--- a/yeoun/week6/예상 대진표.py
+++ b/yeoun/week6/예상 대진표.py
@@ -1,13 +1,8 @@
 # a,b 참가자가 현재 라운드에서 만나면 True, 아니면 False 
 # 둘의 차가 1이고, 큰 값이 짝수여야 만남 
 def check_if_meet(a,b):
-    if a < b:
-        if b-a == 1 and a % 2 == 1 and b % 2 == 0:
-            return True
-
-    else: # a > b
-        if a-b == 1 and a % 2 == 0 and b % 2 == 1:
-            return True
+    if abs(a-b) == 1 and max(a,b) % 2 == 0:
+        return True
     
     return False 
 
@@ -33,3 +28,4 @@ def solution(n,a,b):
         answer += 1 
             
     return answer 
+

--- a/yeoun/week6/완주하지 못한 선수.py
+++ b/yeoun/week6/완주하지 못한 선수.py
@@ -1,0 +1,4 @@
+from collections import Counter
+
+def solution(participant, completion):
+    return list((Counter(participant) - Counter(completion)).keys())[0]

--- a/yeoun/week6/이중우선순위큐.py
+++ b/yeoun/week6/이중우선순위큐.py
@@ -1,0 +1,27 @@
+def operate(q, operation):
+    # 삽입 
+    if operation.startswith('I'):
+        num = int(operation.split()[-1])
+        q += [num]
+    # 최댓값 삭제
+    elif operation == 'D 1':
+        if q:
+            q.remove(max(q))
+    
+    # 최솟값 삭제
+    else:
+        if q:
+            q.remove(min(q))
+    
+    return q
+
+def solution(operations):
+    q = []
+    for operation in operations:
+        q = operate(q, operation)
+    
+    # 큐가 비어있는 경우 
+    if not q:
+        return [0,0]
+    
+    return [max(q), min(q)]

--- a/yeoun/week6/크레인 인형뽑기 게임.py
+++ b/yeoun/week6/크레인 인형뽑기 게임.py
@@ -1,26 +1,28 @@
+def nonzero2list(tuples):
+    result = []
+    for t in tuples:
+        if t != 0:
+            result.append(t)
+    # 위에 있는 인형이 더 끝에 오도록
+    return result[::-1]
+
 def solution(board, moves):
     # 터뜨러져 사라진 횟수
     answer = 0
     
     # 각 세로줄의 인형들 
-    transposed_board = list(map(list, zip(*board)))
+    dolls_per_line = list(map(nonzero2list, zip(*board)))
     
     # 바구니
     basket = []
     for move in moves:
-        for idx, element in enumerate(transposed_board[move-1]):
-            # 인형이 있는 경우 
-            if element != 0:
-                # 현재 칸의 값을 인형으로 저장 
-                doll = element
-                # 인형이 꺼내진 것이므로 빈 칸을 의미라는 0으로 수정
-                transposed_board[move-1][idx] = 0
-                break
-                
-        # break로 for문을 빠져나오지 않은 경우
-        # 즉, 해당 세로줄에 인형이 없는 경우 
-        else:
-            continue
+        dolls = dolls_per_line[move-1]
+        # 인형이 있는 경우 
+        if not dolls:
+            continue 
+
+        doll = dolls.pop()
+
         
         # 바구니가 비어있거나, 마지막으로 쌓인 인형이 현재 인형과 다른 경우 
         if basket == [] or basket[-1] != doll:

--- a/yeoun/week6/크레인 인형뽑기 게임.py
+++ b/yeoun/week6/크레인 인형뽑기 게임.py
@@ -1,0 +1,37 @@
+def solution(board, moves):
+    # 터뜨러져 사라진 횟수
+    answer = 0
+    
+    # 각 세로줄의 인형들 
+    transposed_board = list(map(list, zip(*board)))
+    
+    # 바구니
+    basket = []
+    for move in moves:
+        for idx, element in enumerate(transposed_board[move-1]):
+            # 인형이 있는 경우 
+            if element != 0:
+                # 현재 칸의 값을 인형으로 저장 
+                doll = element
+                # 인형이 꺼내진 것이므로 빈 칸을 의미라는 0으로 수정
+                transposed_board[move-1][idx] = 0
+                break
+                
+        # break로 for문을 빠져나오지 않은 경우
+        # 즉, 해당 세로줄에 인형이 없는 경우 
+        else:
+            continue
+        
+        # 바구니가 비어있거나, 마지막으로 쌓인 인형이 현재 인형과 다른 경우 
+        if basket == [] or basket[-1] != doll:
+            # 바구니에 인형을 넣음 
+            basket.append(doll)
+        
+        # 바구니의 마지막 인형이 현재 인형과 다른 경우 
+        else:
+            # 터뜨러져 사라진 횟수 + 1 
+            answer += 1 
+            basket.pop()
+    
+    # 터트러져 사라진 인형의 개수 = 터뜨러져 사라진 횟수 * 2 
+    return answer * 2

--- a/yeoun/week6/후보키.py
+++ b/yeoun/week6/후보키.py
@@ -1,0 +1,31 @@
+from itertools import combinations
+
+def solution(relation):
+    # key의 개수 
+    N = len(relation[0])
+    key_idx = list(range(N))
+    candidate_keys = []
+    
+    for i in range(1,N+1):
+        for comb in combinations(key_idx, i):
+            hist = []
+            for rel in relation:
+                current_key = [rel[c] for c in comb]
+                # 하나라도 중복되는 경우: 식별 불가능 
+                if current_key in hist:
+                    break
+                else:
+                    hist.append(current_key)
+            # 하나도 중복 안 된 경우: 식별 가능
+            else:
+                for ck in candidate_keys:
+                    # 최소성 확인 
+                    if set(ck).issubset(set(comb)):
+                        break
+                else:
+                    candidate_keys.append(comb)
+    
+    return len(candidate_keys)
+    
+    
+    


### PR DESCRIPTION
## 문제1 (완주하지 못한 선수)
간단하게 `Counter`를 사용하여 풀이했습니다

## 문제2 (크레인 인형뽑기)
`answer`에 인형이 터뜨러져 사라진 횟수를 저장합니다.
입력으로 주어진 `board`를 전치하여 `transposed_board`를 만들고, 각 행에 세로줄의 인형들이 올 수 있게 만들었습니다.
`move`에서 주어진 세로줄에 접근하여 차례로 아래로 내려가며(인덱스를 증가해가며) 인형이 있으면 그 위치의 값을 0으로 만들어 인형이 꺼내졌음을 표시합니다. 
그 후 바구니가 비어있거나 바구니의 가장 위(가장 마지막)에 있는 인형이 현재 인형과 다른 경우 바구니에 인형을 넣고(리스트에 추가하고), 
바구니의 마지막 인형이 현재 인형과 다른 경우는 인형이 터뜨려져야 하기 때문에 `answer`를 1 증가시키고, 마지막 인형도 없애줍니다.

해당 세로줄의 끝까지 갔는데 인형이 없는 경우는 아무 변화 없이 다음 `move`에서 주어진 세로줄에 접근합니다. 

한 번 터뜨러질 때 인형 2개가 사라지므로, 모든 `moves`를 이행한 후 `answer`에 `2`를 곱한 값을 반환합니다.

## 문제3 (예상 대진표)
`answer`에 `a`,`b`가 만나는 라운드의 번호를 저장합니다. 처음엔 1로 초기화합니다. 
`check_if_meet` 함수를 통해 현재 라운드에서 `a`,`b`가 만나는지 확인합니다. `a`,`b`가 만나려면 둘의 차가 `1`이고 둘 중 더 큰 값이 짝수여야 합니다. 
`next_num` 함수는 현재 선수의 번호를 받으면, 다음 라운드에 이 선수에게 주어질 번호를 반환합니다.

`a`,`b`가 `check_if_meet`에서 `True`를 반환할 때까지 `a`,`b`를 다음 라운드의 번호로 갱신하고 `answer`를 `1`씩 증가시킵니다. 

## 문제4 (후보키)
좀 더 효율적으로 풀고 싶은데 그렇지 못해서 아쉬움이 남습니다..
`candidate_keys`라는 리스트에 유일성과 최소성을 모두 만족하는 후보키의 인덱스를 저장합니다.
먼저 key, 혹은 column의 개수를 `N`으로 저장합니다. 

그리고 `1`에서 `N`까지 증가하며 각 key의 combination을 구합니다. 이 combination에서 선택된 key들만을 이용해 각 학생을 표현하는 리스트인 `current_key`를 만들고, 이 `current_key`가 중복되는 경우 다음 combination으로 넘어갑니다. 
하나도 중복되지 않는 경우, 최소성을 확인하기 위해 이미 구한 combination이 지금 구한 combination의 부분집합이 아닌지 확인합니다. 부분집합이 아니라면 `current_key`에 현재 combination을 추가합니다.
마지막으로 `current_key`의 길이를 반환합니다. 

## 문제5 (이중우선순위큐)
힙을 사용하지 않으면 효율성 통과가 안 될 줄 알았는데, 그냥 리스트를 써도 통과가 되네요..

`operate` 함수를 통해 각 명령어를 식별하고, 삽입의 경우 리스트 맨 뒤에 숫자를 삽입, 최댓값 및 최솟값은 `max`, `min` 함수를 사용하고 `remove`를 통해 삭제했습니다. 
(지금 생각해보니 만약에 최댓값이나 최솟값이 2개 이상이면 어떻게 해야 하는지 문제에 설명을 안 했네요?! 그냥 하나만 삭제하는 걸까요)
`for` 문을 통해 각 명령어를 차례로 이행해주고, 큐가 비어있는 경우 `[0,0]`을, 아닌 경우 `max`, `min` 함수를 이용해 `[최댓값, 최솟값]`을 반환했습니다.
