### PR TITLE
7주차 문제

### DIFF
--- a/bmo/week7/JadenCase문자열.py
+++ b/bmo/week7/JadenCase문자열.py
@@ -1,0 +1,15 @@
+def solution(s):
+    answer = ""
+    space = True
+
+    for c in s:
+        if c == ' ':
+            answer += c
+            space = True
+        elif space:
+            answer += c.upper()
+            space = False
+        else:
+            answer += c.lower()
+
+    return answer

--- a/bmo/week7/보석쇼핑.py
+++ b/bmo/week7/보석쇼핑.py
@@ -1,0 +1,13 @@
+def solution(gems):
+    answer = []
+    total = set(gems)
+    n = len(total)
+
+    for i in range(len(gems)-n):
+        for j in range(i+n, len(gems)+1):
+            curr = set(gems[i:j])
+            
+            if total.issubset(curr):
+                answer.append((j-i, i+1, j))
+    answer.sort()
+    return [answer[0][1], answer[0][2]]

--- a/bmo/week7/오픈채팅방.py
+++ b/bmo/week7/오픈채팅방.py
@@ -1,0 +1,25 @@
+def solution(record):
+    answer = []
+    users = dict()
+    COMMAND, UID, NICK = 0, 1, 2
+    
+    for log in record:
+        log = log.split()
+        if log[COMMAND] == 'Enter':
+            users[log[UID]] = log[NICK]
+        elif log[COMMAND] == 'Change':
+            users[log[UID]] = log[NICK]
+    
+    for log in record:
+        log = log.split()
+        if log[COMMAND] == 'Enter':
+            log[COMMAND] = '들어왔습니다'
+        elif log[COMMAND] == 'Leave':
+            log[COMMAND] == '나갔습니다'
+        else:
+            continue
+        answer.append(f'{users[log[UID]]}님이 {log[COMMAND]}')
+    return answer
+
+if __name__ == '__main__':
+    solution(["Enter uid1234 Muzi", "Enter uid4567 Prodo","Leave uid1234","Enter uid1234 Prodo","Change uid4567 Ryan"])

--- a/bmo/week7/조이스틱.py
+++ b/bmo/week7/조이스틱.py
@@ -1,0 +1,23 @@
+def solution(name):
+    answer = 0
+    gaps = []
+    for c in name:
+        gap = ord(c) - ord('A') if ord(c) - ord('A') < 13 else ord('Z') - ord(c) + 1
+        gaps.append(gap)
+    
+    answer = sum(gaps)
+    skip = 0
+
+    for i in range(len(gaps)):
+        print(gaps[i])
+        if gaps[i] == 0:
+            skip += 1
+        else:
+            if i > 1:
+                break
+
+    answer += len(gaps) - skip - 1
+    return answer
+
+if __name__ == '__main__':
+    solution("ZZAAAZZ") # 이 경우, 왔던 칸으로 돌아가는 것이 더 빠르다

--- a/bmo/week7/체육복.py
+++ b/bmo/week7/체육복.py
@@ -1,0 +1,27 @@
+from collections import defaultdict
+
+def solution(n, lost, reserve):
+    student = defaultdict(int)
+
+    for i in range(1, n+1):
+        student[i] += 1
+    for l in lost:
+        student[l] -= 1
+    for r in reserve:
+        student[r] += 1
+    
+    for i in range(n, 1, -1):
+        if student[i] == 2 and student[i-1] == 0:
+            student[i] -= 1
+            student[i-1] += 1
+
+    for i in range(1, n):
+        if student[i] == 2 and student[i+1] == 0:
+            student[i] -= 1
+            student[i+1] += 1
+
+    for value in student.values():
+        if value == 0:
+            n -= 1
+
+    return n


### PR DESCRIPTION
# 체육복
`학생번호 : 체육복` 쌍인 `딕셔너리`를 사용하였습니다.
기본적으로 모두 1개의 체육복을 갖고 있는데 여벌이 있는 학생과 잃어버린 학생 리스트를 다 돌면
체육복이 없는 학생은 0, 본인이 쓸 체육복만 있는 학생은 1, 빌려줄 수 있는 학생은 2 값을 가진 딕셔너리가 됩니다. 체격순이라 자신의 바로 앞번호와 뒷번호만 빌려줄 수 있으므로
1. (n번~1번)으로 돌면서 현재 학생이 자신의 바로 앞 학생에게 빌려 줄 수 있으면 빌려주고
2. (1번~n번)으로 돌면서 현재 학생이 자신의 바로 뒤 학생에게 빌려 줄 수 있으면 빌려줍니다
3. 가능한 모두 빌려주고도 체육복이 0인 학생의 수를 전체학생에서 뺀 수가 수업을 받을 수 있는 학생수입니다.
- 시간 복잡도: O(N)
- 🤔 처음에 테스트케이스 11을 통과하지 못했습니다. `앞~뒤` 빌려주고 그 다음 `뒤~앞` 빌려주는 식으로 순서를 바꿔주니 테스트케이스 11을 통과할 수 있었습니다. 뭐가 다른지 더 생각해봐야겠습니다...
# 오픈채팅방
`uid : 닉네임` 쌍인 딕셔너리 사용하였습니다
1. 입장, 변경 -> 딕셔너리에서 해당 uid의 닉네임값을 갱신했습니다.
2. 적절한 한국어 명령어로 바꾸어 출력 리스트 answer에 추가했습니다
- 시간 복잡도: O(N)
# 조이스틱
영어 알파벳이 26자이므로 바꿔야하는 문자가 A와 13이상 차이라면 🔽로 바꿉니다
1. 각 위치별 문자를 바꿔야하는 횟수를 gaps리스트에 저장합니다
2. 오른쪽으로 이동하는 것을 기본으로 하고 도중에 바꾸는 횟수가 0이 연달아 있는 경우 돌아가는 것이 더 효율적이라고 봅니다
-- 왔던 칸으로 돌아가는 것이 더 빠른 경우를 처리하지 못하는 문제가 있어서 마지막 테스트케이스는 통과하지 못하고 있네요😂
# JadenCase문자열
처음에 split()을 사용했는데 이 경우 의도적으로 공백도 그대로 쓰고 싶은 경우는 공백을 날려버리는 문제가 있었습니다. 
1. 문자열 그대로 받고 space변수에 공백여부를 저장해서 공백이 True인 상태에서 공백이 아닌 문자가 온다면 대문자로
2. 공백이 False인 상태에서 공백이 아닌 문자가 오면 소문자로 바꿔서 출력 문자열에 더해나갑니다.
- 시간 복잡도: O(N)
# 보석쇼핑
보석종류 n개
1. 앞에서부터 n~끝까지의 구간을 뭉텅이로 잡고 그 리스트를 set으로 변환하면 중복이 제거되므로 모든 종류가 들어있는지 확인할 수 있습니다. 
2. 모든 종류 보석이 들어있는 구간이라면 (구간길이, 시작, 끝)을 answer 리스트에 저장합니다
3. answer리스트를 정렬시키면 맨 앞 원소가 가장 구간길이가 짧으므로 그 원소의 1, 2번째 원소를 출력합니다. 
- 시간 복잡도: O(N^2)
- 정확도, 효율성 통과 못해서 더 수정해봐야겠습니다.🤨