### PR TITLE
yeoun-week11

### DIFF
--- a/yeoun/week11/가사 검색(시간초과1,2).py
+++ b/yeoun/week11/가사 검색(시간초과1,2).py
@@ -1,0 +1,22 @@
+import re
+from collections import defaultdict
+
+def solution(words, queries):
+    queries = [query.replace('?', '.') for query in queries]
+    words.sort(key=lambda x: len(x))
+    
+    matching_dict = defaultdict(int)
+    
+    for q in set(queries):
+        for word in words:
+            if len(word) == len(q):
+                result = re.match(q, word)
+                if result:
+                    matching_dict[q] += 1 
+            elif len(word) > len(q):
+                break
+    
+    answer = []
+    for query in queries:
+        answer.append(matching_dict[query])
+    return answer

--- a/yeoun/week11/가사 검색.py
+++ b/yeoun/week11/가사 검색.py
@@ -1,0 +1,76 @@
+from collections import defaultdict
+
+# 이진 탐색 
+def binary_search(array, suffix_idx, target, start, end, result):
+    if start > end:
+        return len(result) 
+
+    mid = (start + end) // 2 
+
+    # 중간값이 타겟인 경우 
+    if array[mid][:suffix_idx] == target:
+        # 현재 인덱스를 result 집합에 추가 
+        result.add(mid)
+        # 현재 인덱스보다 작은 쪽, 큰 쪽 모두 가보기 
+        binary_search(array, suffix_idx, target, start, mid - 1, result)
+        binary_search(array, suffix_idx, target, mid + 1, end, result)
+
+    # 중간값이 타겟보다 큰 경우 
+    elif target < array[mid][:suffix_idx]:
+        binary_search(array, suffix_idx, target, start, mid - 1, result)
+
+    # 중간값이 타겟보다 작은 경우 
+    else:
+        binary_search(array, suffix_idx, target, mid + 1, end, result)
+
+    return len(result) 
+
+def solution(words, queries):
+    # key: 단어 길이, value: 해당 길이의 단어들 
+    word_dict = defaultdict(list)
+    # key: 단어 길이, value: 해당 길이의 단어들의 앞뒤를 뒤집은 형태 
+    reversed_word_dict = defaultdict(list)
+    for word in words:
+        word_dict[len(word)].append(word)
+        reversed_word_dict[len(word)].append(word[::-1])
+
+    # value를 알파벳 순으로 정렬 
+    word_dict = {key: sorted(words) for key, words in word_dict.items()}
+    reversed_word_dict = {key: sorted(words) for key, words in reversed_word_dict.items()}
+    
+    matching_dict = defaultdict(int)
+    
+    for q in set(queries):
+        # query가 ?로만 이루어진 경우 
+        if set(q) == set('?'):
+            if len(q) not in word_dict:
+                matching_dict[q] = 0
+                continue        
+            matching_dict[q] = len(word_dict[len(q)])
+            
+        # query의 접미사가 ?인 경우 
+        elif not q.startswith('?'):
+            if len(q) not in word_dict:
+                matching_dict[q] = 0
+                continue 
+            array = word_dict[len(q)]
+            suffix_idx = q.index('?')
+            target = q[:suffix_idx]
+            matching_dict[q] = binary_search(array, suffix_idx, target, 0, len(array)-1, result=set())
+            
+        # query의 접두사가 ?인 경우 
+        # query의 앞뒤를 뒤집어 접미사인 경우와 동일하게 탐색 
+        else:
+            if len(q) not in reversed_word_dict:
+                matching_dict[q] = 0
+                continue 
+            array = reversed_word_dict[len(q)]
+            prefix_idx = q[::-1].index('?')
+            target = q[::-1][:prefix_idx]
+            matching_dict[q] = binary_search(array, prefix_idx, target, 0, len(array)-1, result=set())
+    
+    # 중복된 query가 있을 수 있으므로 
+    answer = []
+    for query in queries:
+        answer.append(matching_dict[query])
+    return answer

--- a/yeoun/week11/고정점 찾기.py
+++ b/yeoun/week11/고정점 찾기.py
@@ -1,17 +1,17 @@
 def fixed_point_search(array, start, end):
     while start <= end:
         mid = (start+end)//2
-        # 고정값이 있으면 고정값 출력 
+        # 고정점이 있으면 고정점 출력 
         if array[mid] == mid:
             return mid
-        # 현재 인덱스보다 값이 큰 경우, 오른쪽으로 이동
+        # 현재 인덱스보다 값이 큰 경우, 왼쪽으로 이동
         elif array[mid] > mid:
             end = mid - 1
-        # 현재 인덱스보다 값이 작은 경우, 왼쪽으로 이동
+        # 현재 인덱스보다 값이 작은 경우, 오른쪽으로 이동
         else:
             start = mid + 1
     
-    # 고정값이 없다면 -1 출력 
+    # 고정점이 없다면 -1 출력 
     return -1
     
 def solution(n, array):

--- a/yeoun/week11/고정점 찾기.py
+++ b/yeoun/week11/고정점 찾기.py
@@ -1,0 +1,20 @@
+def fixed_point_search(array, start, end):
+    while start <= end:
+        mid = (start+end)//2
+        # 고정값이 있으면 고정값 출력 
+        if array[mid] == mid:
+            return mid
+        # 현재 인덱스보다 값이 큰 경우, 오른쪽으로 이동
+        elif array[mid] > mid:
+            end = mid - 1
+        # 현재 인덱스보다 값이 작은 경우, 왼쪽으로 이동
+        else:
+            start = mid + 1
+    
+    # 고정값이 없다면 -1 출력 
+    return -1
+    
+def solution(n, array):
+    N = len(array)
+    return fixed_point_search(array, start=0, end=N-1)
+

--- a/yeoun/week11/공유기 설치.py
+++ b/yeoun/week11/공유기 설치.py
@@ -1,0 +1,49 @@
+import sys
+
+# 입력 받아오기 
+inputs = list(map(int, sys.stdin.read().split()))
+
+# 집의 개수
+N = inputs[0]
+# 설치할 공유기의 개수 
+C = inputs[1]
+# 집의 좌표들
+homes = inputs[2:]
+
+# 오름차순으로 정렬
+homes.sort()
+
+# 최대 떨어진 거리
+max_gap = homes[-1] - homes[0]
+# 최소 떨어진 거리 
+min_gap = 1 
+answer = None
+
+# 이진 탐색 
+while min_gap <= max_gap:
+    # 떨어진 거리의 중간값 
+    mid_gap = (max_gap + min_gap) // 2
+    
+    # 현재 공유기를 설치한 집의 좌표 
+    current = homes[0]
+    # mid_gap에 따라 설치할 수 있는 공유기의 개수 
+    count = 1
+    
+    for i in range(1, N):
+        # 직전에 설치한 공유기보다 mid_gap 이상 떨어진 곳에 공유기 설치
+        if homes[i] >= current + mid_gap:
+            current = homes[i]
+            count += 1 
+    
+    # C 이상의 공유기를 설치할 수 있는 경우 
+    if count >= C:
+        # 격차를 늘림 
+        min_gap = mid_gap + 1 
+        # 현재 격차를 answer로 중간 저장 
+        answer = mid_gap
+    # C보다 적은 공유기만 설치할 수 있는 경우 
+    else:
+        # 격차를 줄임 
+        max_gap = mid_gap - 1 
+
+print(answer)

--- a/yeoun/week11/정렬된 배열에서 특정 수의 개수 구하기.py
+++ b/yeoun/week11/정렬된 배열에서 특정 수의 개수 구하기.py
@@ -1,0 +1,30 @@
+# 이진 탐색 소스코드 구현(재귀 함수)
+def binary_search(array, target, start, end, result):
+    if start > end:
+        # x인 원소가 하나도 없다면 -1 출력 
+        return len(result) if len(result) > 0 else -1 
+    
+    mid = (start + end) // 2 
+    
+    # 중간값이 타겟인 경우 
+    if array[mid] == target:
+        # 현재 인덱스를 result 집합에 추가 
+        result.add(mid)
+        # 현재 인덱스보다 작은 쪽, 큰 쪽 모두 가보기 
+        binary_search(array, target, start, mid - 1, result)
+        binary_search(array, target, mid + 1, end, result)
+        
+    # 중간값이 타겟보다 큰 경우 
+    elif array[mid] > target:
+        binary_search(array, target, start, mid - 1, result)
+        
+    # 중간값이 타겟보다 작은 경우 
+    else:
+        binary_search(array, target, mid + 1, end, result)
+        
+    # x인 원소가 하나도 없다면 -1 출력 
+    return len(result) if len(result) > 0 else -1 
+
+def solution(N, x, array):
+    return binary_search(array, x, 0, N-1, result=set())
+    


### PR DESCRIPTION
## 문제1 (정렬된 배열에서 특정 수의 개수 구하기)
재귀함수로 구현한 이진 탐색 코드를 참고하여 풀이했습니다. 
타겟 값이 있는 인덱스를 `result`라는 집합에 모두 추가하고 이 집합의 길이를 반환했습니다. 기존의 이진 탐색과 동일하지만, 중간값이 타겟과 같은 경우 현재 중간값을 `result` 집합에 추가해주었고, 왼쪽과 오른쪽 모두에 타겟이 더 있을 수 있으므로 `end`를 `mid-1`로 갱신한 탐색, `start`를 `mid+1`로 갱신한 탐색 모두를 진행하도록 했습니다. 타겟 원소가 하나도 없으면 `-1`을 출력하도록 했으므로 `result`의 길이가 `0`보다 크면 `len(result)`를, 그렇지 않으면 `-1`을 출력하도록 했습니다. 

## 문제2 (고정점 찾기)
반복문으로 구현한 이진 탐색 코드를 참고하여 풀이했습니다. 
고정점을 찾기 위해 `if`, `elif`, `else` 조건만 바꿔주어, 고정값을 찾으면 고정값을 반환하고, 현재 인덱스보다 현재 값이 더 큰 경우 왼쪽으로 이동(`end`를 `mid-1`로 갱신), 현재 인덱스보다 현재 값이 더 작은 경우 오른쪽으로 이동(`start`를 `mid+1`로 갱신)시킵니다. 

## 문제3 (공유기 설치)
_전혀 모르겠어서 답지를 보고 말았네요~!~! 😂_

`C`개의 공유기를 설치할 수 있는 가장 인접한 공유기 사이의 최대 거리를 이진탐색으로 탐색합니다. 최소 거리 `min_gap`을 `1`로, 최대 거리 `max_gap`은 `(집 좌표 중 가장 큰 값) - (집 좌표 중 가장 작은 값)`으로 설정합니다. 이후 `min_gap`과 `max_gap`의 중간값인 `mid_gap`을 구하며 다음을 반복합니다.
`mid_gap`일 때 설치 가능한 공유기 개수를 `count`에 저장합니다. 이 `count` 값이 `C` 이상이면 거리를 늘릴 수 있으므로 `min_gap`을 `mid_gap + 1` 값으로 갱신합니다. 그리고 현재 `mid_gap` 값을 `answer`로 저장합니다. 반대로 `count` 값이 `C`보다 작은면 거리를 좁혀야 하므로 `max_gap`을 `mid_gap - 1` 값으로 갱신합니다. 이를 `min_gap`이 `max_gap`보다 작거나 같을 때까지 반복합니다.
`while`문을 탈출한 후 `answer`를 최종 정답으로 반환합니다.

## 문제4 (가사 검색)
_이번에도 답지를 참고 했지만... 마지막 양심으로 코드는 안 봤습니다 ㅎ .._ 

먼저 `단어의 길이`가 `key`, `해당 길이의 단어들의 리스트`를 `value`로 갖는 `word_dict`를 생성합니다. 같은 방식으로 단어의 앞뒤를 뒤집은 `reversed_word_dict`도 생성합니다.
`matching_dict`라는 딕셔너리를 만들어 `key`는 `하나의 쿼리`, `value`는 `해당 쿼리에 매칭되는 단어의 개수`를 저장합니다. 
이후 `queries`를 하나씩 꺼내면서 현재의 쿼리가 `?`로만 이루어져 있으면 해당 쿼리 길이의 단어들의 개수를 `matching_dict`에 저장합니다. 
쿼리가 `?`를 접미사로 가지면, 해당 쿼리 길이의 단어들을 `array`, `target`은 `?`를 제외한 알파벳으로 두고 이진 탐색을 실행합니다. 이진 탐색 함수는 #22 (문제1)의 함수를 약간만 수정했습니다. `'ab' < 'ac'` 등 string의 알파벳 정렬 순서로 `<`, `>`, `==` 등의 연산이 가능함을 이용했습니다. 
쿼리가 `?`를 접두사로 가지면, 쿼리의 앞뒤를 뒤집고, 단어들도 뒤집은 형태를 활용하여 `?`를 접미사로 가질 때와 동일하게 이진탐색을 실행했습니다.
모든 쿼리에 대해 매칭 가능한 단어의 개수를 구한 뒤, 각 쿼리당 단어 개수를 리스트로 만들어 최종 정답으로 반환했습니다.