### PR TITLE
yeoun-week12

### DIFF
--- a/yeoun/week12/숨바꼭질.py
+++ b/yeoun/week12/숨바꼭질.py
@@ -1,0 +1,46 @@
+import sys
+import heapq
+
+INF = int(1e9)
+
+# 입력 받아오기 
+inputs = list(map(int, sys.stdin.read().split()))
+N = inputs[0]
+M = inputs[1]
+routes = inputs[2:]
+
+graph = [[] for _ in range(N+1)]
+distance = [INF] * (N+1)
+
+for i in range(0, len(routes), 2):
+    a, b = routes[i], routes[i+1]
+    # 양방향
+    graph[a].append((b,1))
+    graph[b].append((a,1))
+
+# 다익스트라 알고리즘 
+def dijkstra(start):
+    q = []
+    heapq.heappush(q, (0, start))
+    distance[start] = 0
+    
+    while q:
+        dist, now = heapq.heappop(q)
+        if distance[now] < dist:
+            continue 
+        for i in graph[now]:
+            # i[0]: 헛간 번호
+            # i[1]: 거리 
+            cost = dist + i[1]
+            if cost < distance[i[0]]:
+                distance[i[0]] = cost
+                heapq.heappush(q,(cost, i[0]))
+                
+dijkstra(1)
+
+# 가장 먼 헛간의 최단거리 
+max_dist = max(distance[1:])
+# 가장 먼 헛간의 최단거리만큼 떨어진 헛간들의 리스트 
+max_barns = [i for i, dist in enumerate(distance) if dist == max_dist]
+# 가장 먼 헛간의 최단거리만큼 떨어진 헛간들 중 헛간 번호가 가장 작은 것, 가장 먼 헛간의 최단거리, 가장 먼 헛간의 최단거리만큼 떨어진 헛간들의 개수
+print(min(max_barns), max_dist, len(max_barns), sep=' ')

--- a/yeoun/week12/정확한 순위.py
+++ b/yeoun/week12/정확한 순위.py
@@ -1,0 +1,37 @@
+import sys
+
+INF = int(1e9)
+
+# 입력 받아오기 
+inputs = list(map(int, sys.stdin.read().split()))
+# 학생 수 
+N = inputs[0]
+# 비교한 결과의 수 
+M = inputs[1]
+# 성적 비교 결과 
+scores = inputs[2:]
+
+graph = [[INF]*(N+1) for _ in range(N+1)]
+
+for i in range(0, len(scores), 2):
+    low, high = scores[i], scores[i+1]
+    graph[low][high] = 1
+    
+
+# 플로이드 워셜 알고리즘 
+for k in range(1, N+1):
+    for a in range(1, N+1):
+        for b in range(1, N+1):
+            graph[a][b] = min(graph[a][b], graph[a][k]+graph[k][b])
+            
+answer = []
+for n in range(1, N+1):
+    transposedGraph = list(zip(*graph))
+    # 그래프의 n번째 가로줄, n번째 세로줄에서 0이 아닌 index들 + 자기 자신의 index를 합치면 1 ~ N이 되는 경우 순위를 알 수 있음 
+    if set([i for i,x in enumerate(graph[n]) if x != INF] + [i for i,x in enumerate(transposedGraph[n]) if x != INF] + [n]) == set(range(1,N+1)):
+        answer.append(n)
+
+# 순위를 알 수 있는 학생의 수  
+print(len(answer))
+
+

--- a/yeoun/week12/플로이드.py
+++ b/yeoun/week12/플로이드.py
@@ -1,0 +1,35 @@
+import sys
+
+INF = int(1e9)
+
+# 입력 받아오기 
+inputs = list(map(int, sys.stdin.read().split()))
+# 도시의 개수 
+n = inputs[0]
+# 버스의 개수 
+m = inputs[1]
+# 버스 노선
+routes = inputs[2:]
+
+graph = [[INF]*(n+1) for _ in range(n+1)]
+
+for i in range(0, len(routes), 3):
+    a, b, c = routes[i], routes[i+1], routes[i+2]
+    # 여러 노선 중 비용이 최소인 것만 
+    graph[a][b] = min(graph[a][b], c)
+
+# 플로이드 워셜 알고리즘 
+for k in range(1, n+1):
+    for a in range(1, n+1):
+        for b in range(1, n+1):
+            graph[a][b] = min(graph[a][b], graph[a][k]+graph[k][b])
+            
+for a in range(1, n+1):
+    for b in range(1, n+1):
+        # 자기 자신으로 가는 경우나 INF일 경우 0  
+        if b == a or graph[a][b] == INF:
+            print(0, end=' ')
+        else:
+            print(graph[a][b], end=' ')
+    print()
+        

--- a/yeoun/week12/화성 탐사.py
+++ b/yeoun/week12/화성 탐사.py
@@ -1,0 +1,47 @@
+import fileinput
+import heapq
+
+INF = int(1e9)
+
+# 입력 처리하기
+nextN = 1
+spaces = []
+for i, line in enumerate(fileinput.input()):
+    if i == 0:
+        continue
+    elif i == nextN:
+        N = int(line)
+        spaces.append([])
+        nextN += N + 1
+    else:
+        spaces[-1].append(list(map(int, line.split())))
+
+# 다익스트라 알고리즘
+def explore(space):
+    N = len(space)
+    # N * N
+    distance = [[INF]*N for _ in range(N)]
+    q = []
+    # (0,0)에서 시작
+    heapq.heappush(q, (0, (0,0)))
+    distance[0][0] = 0
+    while q:
+        dist, now = heapq.heappop(q)
+        x,y = now
+        if distance[x][y] < dist:
+            continue
+        # 상, 하, 좌, 우
+        adjs = [(x-1, y), (x+1, y), (x, y-1), (x, y+1)]
+        for adj in adjs:
+            a, b = adj
+            if a in range(0,N) and b in range(0,N):
+                cost = dist + space[a][b]
+                if cost < distance[a][b]:
+                    distance[a][b] = cost
+                    heapq.heappush(q, (cost, (a,b)))
+
+    # (N-1, N-1)까지 가는데 소모되는 에너지 + (0,0)을 지나는데 소모되는 에너지
+    return distance[N-1][N-1] + space[0][0]
+
+for space in spaces:
+    print(explore(space))


### PR DESCRIPTION
## 문제1 (플로이드)
2가지 수정사항을 제외하고 모두 책의 플로이드 워셜 구현 코드를 그대로 활용했습니다.
(1) 시작 도시와 도착 도시를 연결하는 노선이 여러 개일 수 있다고 했으므로, 여러 개의 노선 중 최솟값만 저장하도록 수정해주었고,
(2) 마지막에 결과를 프린트할 때 `INFINITY` 대신 `0`을 프린트하도록 수정했습니다. 
* 시간복잡도: O(N^3)

## 문제2 (정확한 순위)
플로이드 워샬 알고리즘을 활용해 풀이했습니다. 현재 학생을 제외한 나머지 학생들이 현재 학생보다 성적이 낮은지, 높은지 모두 알면 그 학생의 정확한 순위를 알 수 있습니다.
A번 학생의 성적이 B번 학생보다 낮다면 화살표가 A에서 B를 가리키도록 하면, 플로이드 워샬 알고리즘 수행 후 그래프의 `n`번째 가로줄(행)에 `INF`가 아닌 숫자가 있으면 그 인덱스의 학생은 `n`번째 학생보다 성적이 높다는 의미입니다. `n`번째 세로줄(열)에 `INF`가 아닌 숫자가 있으면,  그 인덱스의 학생은 `n`번째 학생보다 성적이 낮다는 의미입니다. 
따라서 `n`번째 행과 열에서 `INF`가 아닌 값을 가지는 인덱스 + 자기 자신의 인덱스(`n`)을 합쳤을 때, `1` ~ `N`(전체 학생 수)이 모두 포함되면 `n`번째 학생은 정확한 순위를 알 수 있습니다. 
* 시간복잡도: O(N^3)

## 문제3 (화성 탐사)
다익스트라 알고리즘을 활용해 풀이했습니다.
우선 입력을 받아 하나의 테스트 케이스는 `N*N` 리스트로 정리하고, 각 테스트 케이스를 `spaces`라는 리스트에 저장했습니다.
화성 탐사 기계는 상하좌우 인접한 곳으로 1칸씩 이동할 수 있다고 했으므로, 그래프의 인접한 노드 대신 상하좌우의 좌표를 탐색하며 풀이했습니다. 이때 `N*N` 리스트 밖으로 나가 `IndexError`가 발생하는 것을 방지하기 위해 인덱스가 `0`~`N-1` 사이인지 확인해주었습니다. 마지막으로 가장 위 칸인 `(0,0)`을 지나는데도 에너지가 소모되므로, 다익스트라 알고리즘이 끝난 후에 `(0,0)`을 지나는데 소모되는 에너지를 더해주었습니다.
* 시간복잡도: O(N^2*logN^2)
   * 간선 개수: 4 * N * (N-1)
   * 노드 개수: N * N  

## 문제4 (숨바꼭질)
`yeoun/week9/가장 먼 노드(다익스트라).py`와 유사하게 풀이했습니다.
다익스트라 알고리즘 코드대로 `graph`, `distance`를 초기화하고 입력에 맞게 `graph` 정보를 저장했습니다. 이후 다익스트라 알고리즘을 실행하여 `distance`를 구한 뒤, `가장 먼 헛간의 최단거리만큼 떨어진 헛간들 중 헛간 번호가 가장 작은 것`, `가장 먼 헛간의 최단거리`, `가장 먼 헛간의 최단거리만큼 떨어진 헛간들의 개수`를 순서대로 반환합니다.
* 시간복잡도: O(M*logN)
   * M: 통로의 개수, N: 헛간의 개수 