### PR TITLE
bmo 13주차 여행계획, 탑승구, 어두운 길, 행성 터널

### DIFF
--- a/bmo/week12/다익스트라.py
+++ b/bmo/week12/다익스트라.py
@@ -1,0 +1,40 @@
+import heapq
+
+def dijkstra(start):
+    queue = []
+    heapq.heappush(queue, (0, start))
+    distance[start] = 0
+
+    while queue:
+        dist, now = heapq.heappop(queue)
+
+        if distance[now] < dist:
+            continue
+
+        for e, c in graph[now]:
+            cost = dist + c
+            if cost < distance[e]:
+                distance[e] = cost
+                heapq.heappush(queue, (cost, e))
+
+if __name__ == '__main__':
+    INF = int(1e9)
+
+    f = open('input.txt', 'r')
+    n, m = map(int, f.readline().split())
+    start = int(f.readline())
+
+    graph = [[] for _ in range(n+1)]
+    distance = [INF] * (n+1)
+
+    for _ in range(m):
+        a, b, c = map(int, f.readline().split())
+        graph[a].append((b, c))
+
+    dijkstra(start)
+
+    for i in range(1, n+1):
+        if distance[i] == INF:
+            print("INF")
+        else:
+            print(distance[i])

--- a/bmo/week13/어두운 길.py
+++ b/bmo/week13/어두운 길.py
@@ -1,0 +1,36 @@
+def find_parent(parent, x):
+    if parent[x] != x:
+        parent[x] = find_parent(parent, parent[x])
+    return parent[x]
+
+def union_parent(parent, a, b):
+    a = find_parent(parent, a)
+    b = find_parent(parent, b)
+
+    if a < b:
+        parent[b] = a
+    else:
+        parent[a] = b
+
+if __name__ == '__main__':
+    f = open('bmo/week13/input3.txt', 'r')
+    n, m = map(int, f.readline().split())
+    parent = [i for i in range(n+1)]
+    edges = []
+    result = 0
+
+    for _ in range(m):
+        a, b, cost = map(int, f.readline().split())
+        edges.append((a, b, cost))
+
+    edges.sort(key=lambda x: x[2])
+    total = 0
+
+    for edge in edges:
+        a, b, cost = edge
+        total += cost
+        if find_parent(parent, a) != find_parent(parent, b):
+            union_parent(parent, a, b)
+            result += cost
+    
+    print(total - result)

--- a/bmo/week13/여행 계획.py
+++ b/bmo/week13/여행 계획.py
@@ -1,0 +1,30 @@
+def find_parent(parent, x):
+    if parent[x] != x:
+        parent[x] = find_parent(parent, parent[x])
+    return parent[x]
+
+def union_parent(parent, a, b):
+    a = find_parent(parent, a)
+    b = find_parent(parent, b)
+
+    if a < b:
+        parent[b] = a
+    else:
+        parent[a] = b
+
+if __name__ == '__main__':
+    f = open('bmo/week13/input1.txt', 'r')
+    n, m = map(int, f.readline().split())
+    parent = [i for i in range(n+1)]
+
+    for i in range(n):
+        cities = list(map(int, f.readline().split()))
+        for j in range(n):
+            if cities[j] == 1:
+                union_parent(parent, i+1, j+1)
+
+    path = set()
+    for city in map(int, f.readline().split()):
+        path.add(parent[city])
+    
+    print('NO') if len(path) > 1 else print('YES')

--- a/bmo/week13/크루스칼.py
+++ b/bmo/week13/크루스칼.py
@@ -1,0 +1,34 @@
+def find_parent(parent, x):
+    if parent[x] != x:
+        parent[x] = find_parent(parent, parent[x])
+    return parent[x]
+
+def union_parent(parent, a, b):
+    a = find_parent(parent, a)
+    b = find_parent(parent, b)
+
+    if a < b:
+        parent[b] = a
+    else:
+        parent[a] = b
+    
+if __name__ == '__main__':
+    f = open('bmo/week13/input.txt', 'r')
+    v, e = map(int, f.readline().split())
+    parent = [i for i in range(v+1)]
+    edges = []
+    result = 0
+
+    for _ in range(e):
+        a, b, cost = map(int, f.readline().split())
+        edges.append((cost, a, b))
+    
+    edges.sort()
+
+    for edge in edges:
+        cost, a, b = edge
+        if find_parent(parent, a) != find_parent(parent, b):
+            union_parent(parent, a, b)
+            result += cost
+    
+    print(result)

--- a/bmo/week13/탑승구.py
+++ b/bmo/week13/탑승구.py
@@ -1,0 +1,29 @@
+def find_parent(parent, x):
+    if parent[x] != x:
+        parent[x] = find_parent(parent, parent[x])
+    return parent[x]
+
+def union_parent(parent, a, b):
+    a = find_parent(parent, a)
+    b = find_parent(parent, b)
+
+    if a < b:
+        parent[b] = a
+    else:
+        parent[a] = b
+
+if __name__ == '__main__':
+    f = open('bmo/week13/input2.txt', 'r')
+    g = int(f.readline())
+    p = int(f.readline())
+    parent = [i for i in range(g+1)]
+    result = 0
+
+    for _ in range(p):
+        gate = int(f.readline())
+        a = find_parent(parent, gate)
+        if a == 0:
+            break
+        union_parent(parent, a, a-1)
+        result += 1
+    print(result)

--- a/bmo/week13/행성 터널.py
+++ b/bmo/week13/행성 터널.py
@@ -22,13 +22,23 @@ if __name__ == '__main__':
 
     for _ in range(n):
         x, y, z = map(int, f.readline().split())
-        nodes.append((x, y, z))
+        nodes.append((_, x, y, z))
     
-    # 뭔가... 이부분 때문에 메모리 초과인거 같은데...
-    for i in range(n):
-        for j in range(i+1, n):
-            edges.append((min([abs(nodes[i][0]-nodes[j][0]), abs(nodes[i][1]-nodes[j][1]), abs(nodes[i][2]-nodes[j][2])]), i, j))
-
+    # x축 
+    nodes.sort(key=lambda x: x[1])
+    for i in range(n-1):
+        edges.append((nodes[i+1][1] - nodes[i][1], nodes[i][0], nodes[i+1][0]))
+    
+    # y축
+    nodes.sort(key=lambda x: x[2])
+    for i in range(n-1):
+        edges.append((nodes[i+1][2] - nodes[i][2], nodes[i][0], nodes[i+1][0]))
+    
+    # z축
+    nodes.sort(key=lambda x: x[3])
+    for i in range(n-1):
+        edges.append((nodes[i+1][3] - nodes[i][3], nodes[i][0], nodes[i+1][0]))
+    
     edges.sort()
     
     for edge in edges:

--- a/bmo/week13/행성 터널.py
+++ b/bmo/week13/행성 터널.py
@@ -1,0 +1,40 @@
+def find_parent(parent, x):
+    if parent[x] != x:
+        parent[x] = find_parent(parent, parent[x])
+    return parent[x]
+
+def union_parent(parent, a, b):
+    a = find_parent(parent, a)
+    b = find_parent(parent, b)
+
+    if a < b:
+        parent[b] = a
+    else:
+        parent[a] = b
+
+if __name__ == '__main__':
+    f = open('bmo/week13/input4.txt', 'r')
+    n = int(f.readline())
+    parent = [i for i in range(n)]
+    nodes = []
+    edges = []
+    result = 0
+
+    for _ in range(n):
+        x, y, z = map(int, f.readline().split())
+        nodes.append((x, y, z))
+    
+    # 뭔가... 이부분 때문에 메모리 초과인거 같은데...
+    for i in range(n):
+        for j in range(i+1, n):
+            edges.append((min([abs(nodes[i][0]-nodes[j][0]), abs(nodes[i][1]-nodes[j][1]), abs(nodes[i][2]-nodes[j][2])]), i, j))
+
+    edges.sort()
+    
+    for edge in edges:
+        cost, a, b = edge
+        if find_parent(parent, a) != find_parent(parent, b):
+            union_parent(parent, a, b)
+            result += cost
+    
+    print(result)

--- a/bmo/week5/디스크 컨트롤러(통과).py
+++ b/bmo/week5/디스크 컨트롤러(통과).py
@@ -1,0 +1,24 @@
+import heapq
+
+def solution(jobs):
+    answer, time, idx = 0, 0, 0
+    start = -1
+    heap = []
+
+    while idx < len(jobs):
+        for j in jobs:
+            if start < j[0] <= time:
+                heapq.heappush(heap, [j[1], j[0]])
+        if len(heap) > 0:
+            current = heapq.heappop(heap)
+            start = time
+            time += current[0]
+            answer += time - current[1]
+            idx += 1
+        else:
+            time += 1
+            
+    return int(answer / len(jobs))
+
+if __name__ == '__main__':
+    print(solution([[24, 10], [28, 39], [43, 20], [37, 5], [47, 22], [20, 47], [15, 34], [15, 2], [35, 43], [26, 1]]))

--- a/bmo/week5/디스크 컨트롤러.py
+++ b/bmo/week5/디스크 컨트롤러.py
@@ -1,0 +1,11 @@
+def solution(jobs):
+    answer = 0
+    time = 0
+
+    # 요청 빨리 끝나는 것부터 처리
+    jobs.sort(key=lambda x: (x[1], x[0]))
+    for call, end in jobs:
+        time += end
+        answer += time - call
+
+    return answer // len(jobs)

--- a/bmo/week9/다익스트라.py
+++ b/bmo/week9/다익스트라.py
@@ -1,0 +1,45 @@
+import heapq
+
+INF = int(1e9)
+
+n = 5
+road = [[1,2,1],[2,3,3],[5,2,2],[1,4,2],[5,3,1],[5,4,2]]
+start = 1
+
+graph = [[] for i in range(n+1)]
+distance = [INF] * (n+1)
+
+for a, b, c in road:
+    graph[a].append((b, c))
+    graph[b].append((a, c))
+
+for line in graph:
+    print(line)
+print()
+
+def dijkstra(start):
+    q = []
+
+    heapq.heappush(q, (0, start))
+    distance[start] = 0
+
+    while q:
+        dist, now = heapq.heappop(q)
+
+        if distance[now] < dist:
+            continue
+
+        for i in graph[now]:
+            cost = dist + i[1]
+
+        if cost < distance[i[0]]:
+            distance[i[0]] = cost
+            heapq.heappush(q, (cost, i[0]))
+
+dijkstra(start)
+
+for i in range(1, n+1):
+    if distance[i] == INF:
+        print("INF")
+    else:
+        print(distance[i])


### PR DESCRIPTION
# 여행계획
-  서로소 집합 자료구조를 사용하였습니다. 양방향 그래프이기 때문에 번호가 큰 노드가 번호가 작은 노드를 간선으로 가리키는 방향으로만 찾아  각 여행지의 루트 노드를 반환할 수 있었습니다. 
- 여행경로의 여행지들의 루트 노들를 set에 저장하여 최종적으로 set의 원소가 1개 뿐일때 모두 방문할 수 있습니다.
- 시간 복잡도: O(MlogN))
# 여행 계획
도전 중...
# 어두운 길
 크루스칼 알고리즘으로 최소 간선 비용으로 모두 연결한 후 전체 간선 비용에서 최소 비용을 뺐습니다. 
- 시간 복잡도: (ElogE)
# 행성 터널
 n의 범위가 1~100000 이므로 O(n)~O(nlogn)까지 허용이라고 생각할 수 있습니다. 처음에 간선 정보를 추가할때 비용을 x, y, z축 절대값 차이에서 한번에 min을 사용해서 구하니 메모리 초과였습니다. 다음과 같은 방법으로 이를 해결했습니다.
-  비용은 x, y, z값을 같이 써서 구한 값이 아니라 x격차, y격차, z격차 중 가장 작은 값을 쓰는 것이므로 
- x, y, z축 각각 격차를 구해 그냥 간선 리스트에 추가 (어차피 전체 간선에서 최소값을 찾아나가기 때문)
  각 축을 기준으로 오름차순 정렬로 다음 인덱스의 값이 현재 인덱스의 위치값보다 크기 때문에 `nodes[i+1][axis] - nodes[i][axis]`는 abs를 사용하지 않아도 양수입니다. 
- 간선 리스트에 (비용, 노드1, 노드2)를 각 축마다 비교해서 추가합니다
- 간선을 오름차순 정렬하고 (x, y, z축 각각 간선 리스트에 넣었지만 정렬을 하면 노드1-노드2 간선이 여러개여도 가장 비용이 작은 간선이 우선되기 때문에 위의 과정이 문제 없습니다. )
- 비용이 적은 간선부터 사이클이 발생하는지 확인하면서 사이클이 없다면 해당 간선(터널) 연결이고 최종 비용에 간선 비용을 더합니다.   

시간 복잡도: O(NlogN)