### PR TITLE
yeoun-week14

### DIFF
--- a/yeoun/week14/금광.py
+++ b/yeoun/week14/금광.py
@@ -1,0 +1,41 @@
+import fileinput
+
+# 입력 처리하기
+for i, line in enumerate(fileinput.input()):
+    if i == 0:
+        # 테스트 케이스 개수
+        N = int(line)
+        tests = []
+        sizes = []
+    elif i % 2 == 1:
+        # 금광 크기
+        a, b = list(map(int, line.split()))
+        sizes.append((a,b))
+        tests.append([[0]*b for _ in range(a)])
+    else:
+        a, b = len(tests[-1]), len(tests[-1][0])
+        vals = list(map(int, line.split()))
+        for row, i in enumerate(range(0, len(vals), b)):
+            tests[-1][row] = vals[i:i+4]
+
+
+for test, size in zip(tests, sizes):
+    a, b = size
+    # 1열, 2열, ... b열까지 
+    for j in range(b):
+        for i in range(a):
+            # 첫 열
+            if j == 0:
+                continue
+            # 첫 행 (왼쪽, 왼쪽 아래에서 접근 가능)
+            elif i == 0:
+                test[i][j] += max(test[i][j-1], test[i+1][j-1])
+            # 마지막 행 (왼쪽 위, 왼쪽에서 접근 가능)
+            elif i == (a-1):
+                test[i][j] += max(test[i-1][j-1], test[i][j-1])
+            # 중간 행 (왼쪽 위, 왼쪽, 왼쪽 아래에서 접근 가능)
+            else:
+                test[i][j] += max(test[i-1][j-1], test[i][j-1], test[i+1][j-1])
+
+    # 마지막 열의 값들 중 최댓값
+    print(max([row[-1] for row in test]))

--- a/yeoun/week14/병사 배치하기.py
+++ b/yeoun/week14/병사 배치하기.py
@@ -1,0 +1,18 @@
+import sys
+
+# 병사 수
+N = int(sys.stdin.readline())
+# 병사들의 전투력
+soldiers = list(map(int, sys.stdin.readline().split()))
+dp = [1] * N
+
+# 0 <= j < i 
+# dp[i] = max(dp[i], dp[j]+1) if soldiers[j] > soldiers[i]
+for i in range(N):
+    for j in range(i):
+        # 내림차순이면 
+        if soldiers[j] > soldiers[i]:
+            dp[i] = max(dp[i], dp[j]+1)
+
+# max(dp)는 가장 긴 내림차순 부분 수열의 길이 
+print(N - max(dp))

--- a/yeoun/week14/정수 삼각형.py
+++ b/yeoun/week14/정수 삼각형.py
@@ -1,0 +1,26 @@
+import sys
+
+# 입력 처리하기
+nums = []
+# 삼각형의 크기
+N = int(sys.stdin.readline())
+for i in range(N):
+    nums.append(list(map(int, sys.stdin.readline().split())))
+
+for i, num in enumerate(nums):
+    # 첫 행
+    if i == 0 :
+        continue
+    for j in range(i+1):
+        # i행의 첫 번째 숫자: 직전 행의 첫 번째 숫자에서만 접근 가능
+        if j == 0:
+            nums[i][j] += nums[i-1][j]
+        # i행의 마지막 숫자: 직전 행의 마지막 숫자에서만 접근 가능
+        elif j == i:
+            nums[i][j] += nums[i - 1][j-1]
+        # 직전 행의 왼쪽, 오른쪽 대각선에서 모두 접근 가능
+        else:
+            nums[i][j] += max(nums[i-1][j-1], nums[i-1][j])
+
+# 마지막 행의 최댓값 
+print(max(nums[-1]))

--- a/yeoun/week14/퇴사.py
+++ b/yeoun/week14/퇴사.py
@@ -1,0 +1,21 @@
+import sys
+
+# 퇴사 전 남은 일 수
+N = int(sys.stdin.readline())
+dp = [0] * (N+1)
+
+for i in range(N):
+    # 소요일자, 이익 
+    t, profit = list(map(int, sys.stdin.readline().split()))
+    # 일이 끝나는 날, 일이 시작되는 날
+    end, start = i+t, i+1
+
+    if end in range(len(dp)) and start-1 in range(len(dp)):
+        # (현재 일이 시작되기 전까지의 이익 + 현재 일을 끝낸 후의 이익)과 (일이 끝나는 날의 기존 dp 값) 중 큰 값을 취함  
+        dp[end] = max(dp[start-1] + profit, dp[end])
+        # 이익이 줄어들 수는 없으므로 
+        for j in range(end+1, len(dp)):
+            dp[j] = max(dp[j], dp[end])
+
+# 마지막 날의 최대 이익 
+print(dp[-1])


### PR DESCRIPTION
## 문제1 (금광)
입력으로 받은 금광에서 1열의 값은 그대로 두고, 2열부터 마지막 열까지 다음을 반복합니다.
첫 행의 경우 현재 위치를 왼쪽, 왼쪽 아래에서부터 접근해올 수 있습니다. 왼쪽 위는 금광이 존재하지 않습니다.
마지막 행의 경우 현재 위치를 왼쪽, 왼쪽 위에서부터 접근해올 수 있습니다. 왼쪽 아래는 금광이 존재하지 않습니다.
중간 행의 경우 현재 위치를 왼쪽, 왼쪽 위, 왼쪽 아래 모두에서 접근해올 수 있습니다. 
접근해올 수 있는 모든 값들 중 최댓값을 현재 금광에서 얻을 수 있는 값과 더해줍니다. 
마지막으로 마지막 열의 모든 값들 중 최댓값을 반환합니다.
* 시간 복잡도: O(N)

## 문제2 (정수 삼각형)
모든 정수를 거쳐가며 다음을 처리합니다.
첫 행은 아무 계산도 하지 않습니다
2번째 행부터 중간에 위치한 정수들은 직전 행의 오른쪽, 왼쪽 대각선의 수 중 큰 것을 더합니다. 첫 번째에 위치한 정수들은 직전 행의 첫 번째 수를 더합니다. 마지막에 위치한 정수들은 직전 행의 마지막 수를 더합니다. 
계산이 끝난 후 마지막 행의 최댓값을 반환합니다.
* 시간 복잡도: O(N)

## 문제3 (퇴사)
각 날짜까지의 누적 이익을 담은 `dp` 리스트를 만듭니다. 처음엔 모두 `0`으로 초기화합니다. 입력을 받으면서 `start`는 현재 일이 시작되는 날, `end`는 현재 일이 끝나는 날, `profit`은 현재 일로 얻을 수 있는 이익으로 정의합니다. 
 `(현재 일이 시작되기 전까지의 이익 + 현재 일을 끝낸 후의 이익)`과 `(일이 끝나는 날의 기존 dp 값)` 중 큰 값을 `dp[end]`로 갱신합니다. 
이때 `end+1`일 이후의 누적 이익이 `end`일까지의 누적 이익보다 적을 수 없으므로 , `dp[end+1:]`의 모든 값을 `현재 자신의 값`과 `갱신된 dp[end] 값` 중 큰 것을 취하도록 합니다.
마지막으로 `dp`의 마지막 요소를 통해 마지막 날의 최대 이익을 반환합니다.
* 시간 복잡도: O(N^2)?

## 문제4 (병사 배치하기)
'가장 긴 증가하는 부분 수열(LIS)'을 이용해 풀이했습니다. 이 문제는 오름차순이 아니라 내림차순을 요구하므로, 점화식의 부등호 방향만 바꾸어줬습니다. `dp`는 모두 `1`로 초기화하고, `soldiers`는 입력으로 받은 병사들의 전투력을 저장합니다. 
`모든 0 <= j < i 에 대해, dp[i] = max(dp[i], dp[j]+1) if soldiers[j] > soldiers[i]`
이후 `dp`의 최댓값을 구하면 가장 긴 내림차순 부분 수열의 길이가 되고, 이를 전체 병사의 수인 `N`에서 빼주면 문제에서 요구하는 열외해야 하는 병사의 수를 구할 수 있습니다.